### PR TITLE
refactors api controller

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,96 +1,17 @@
 # frozen_string_literal: true
 
 class ApiController < ApplicationController
+  include ApiHelper
   def stock_and_pricing
-    # In the real world this call takes a second or two.
-    sleep 1
-
-    account = current_account
-    raise "Account was not found" if account.blank?
-
-    product = Product.find(params[:sku])
-
-    output = {
-      pricing: {
-        retail: {
-          base: {
-            usd: product.base_price__retail(:usd, :unit, :single),
-            cad: product.base_price__retail(:cad, :unit, :single)
-          },
-          markup: {
-            usd: product.retail_price(account: account, currency: :usd, unit: :unit, type: :single),
-            cad: product.retail_price(account: account, currency: :cad, unit: :unit, type: :single)
-          },
-          customer: {
-            usd: product.your_price_retail(account, :usd, :unit),
-            cad: product.your_price_retail(account, :cad, :unit)
-          }
-        },
-        net: {
-          base: {
-            usd: product.base_price__net(:usd, :unit, :single),
-            cad: product.base_price__net(:cad, :unit, :single)
-          },
-          account_cost: {
-            usd: product.your_price_net(account, :usd, :unit),
-            cad: product.your_price_net(account, :cad, :unit)
-          },
-          piece: {
-            usd: product.your_price_net(account, :usd, :piece),
-            cad: product.your_price_net(account, :cad, :piece)
-          },
-          halfpiece: {
-            usd: product.your_price_net(account, :usd, :halfpiece),
-            cad: product.your_price_net(account, :cad, :halfpiece)
-          },
-          customer: {
-            unit: product.order_price__net(current_user, :unit),
-            piece: product.order_price__net(current_user, :piece),
-            halfpiece: product.order_price__net(current_user, :halfpiece)
-          }
-        }
-      },
-      stock: product.stock(current_user)&.merge(unit: product.measured_unit)
-    }
-
-    output[:uom_display_text] = product.measured_unit["uom_display_text"] if product.measured_unit["uom_display_text"].present?
-
-    if product.wallcovering?
-      output[:measured_unit] = product.measured_unit["long"]["singular"].downcase
-      output[:order_increment] = product.wallcovering_data.average_bolt.to_f
-    end
-
-    output[:pricing].delete(:net) unless current_user.has_role?(:view_net_pricing_usd) || current_user.has_role?(:view_net_pricing_cad)
-    output.delete(:stock) unless current_user.has_role?(:view_stock)
-
-    @product = product
-    @stock_output = output[:stock].deep_symbolize_keys
-
-    @stock_total = @stock_output[:current][:total]
-    @stock_unit = @stock_output[:unit][:long][@stock_total == 1 ? :singular : :plural]
-
-    @stock_total_reserved = @stock_output[:total_reserved]
-    @stock_total_reserved_unit = @stock_output[:unit][:long][@stock_total_reserved == 1 ? :singular : :plural]
-
-    @has_stock = @stock_total.present? && @stock_total.to_f.positive?
-    @has_availability = @stock_output[:availability].present?
-    @incoming_stock = @stock_output[:expected]
-
-    # Get all bolts and separate them into "regular bolts" and "small cuts"
-    @bolts = @stock_output[:current][:bolts]
-
-    # Small cuts applies to fabric sold by the yard, excluding Clarencehouse
-    if !clarencehouse? && @product.fabric? && @product.measured_unit["long"]["singular"] == "Yard"
-      @regular_bolts, @small_cuts = @bolts.partition { |_bolt, lot| lot[:quantity].to_f >= 5 } if @bolts.present?
-    else
-      @regular_bolts = @bolts
-      @small_cuts = nil
-    end
-
-    # Group and sort by dye lot number
-    @regular_bolts_dye_lots = @regular_bolts.group_by { |_bolt, lot| lot[:dye_lot] } if @regular_bolts.present?
-    @small_cuts_dye_lots = @small_cuts.group_by { |_bolt, lot| lot[:dye_lot] } if @small_cuts.present?
+    ApiHelper.calculate(Product.find(params[:sku]), current_account, current_user, clarencehouse?)
+    build_view_attributes
   rescue => e
     render json: { success: false, error: e.message }, status: :unprocessable_entity
+  end
+
+  private
+
+  def build_view_attributes
+    ApiHelper.class_variables.map { |cv| eval("#{cv.to_s[1..-1]} = #{cv}") }
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,8 +21,4 @@ class ApplicationController < ActionController::Base
   def clarencehouse?
     false
   end
-
-  def number_to_currency(price)
-    ActionController::Base.helpers.number_to_currency(price)
-  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,4 +21,8 @@ class ApplicationController < ActionController::Base
   def clarencehouse?
     false
   end
+
+  def number_to_currency(price)
+    ActionController::Base.helpers.number_to_currency(price)
+  end
 end

--- a/app/helpers/api_helper.rb
+++ b/app/helpers/api_helper.rb
@@ -6,8 +6,8 @@ module ApiHelper
       pricing: {
         retail: {
           base: {
-            usd: product.base_price__retail(:usd, :unit, :single),
-            cad: product.base_price__retail(:cad, :unit, :single)
+            usd: product.base_price_retail(:usd, :unit, :single),
+            cad: product.base_price_retail(:cad, :unit, :single)
           },
           markup: {
             usd: product.retail_price(account: account, currency: :usd, unit: :unit, type: :single),
@@ -20,8 +20,8 @@ module ApiHelper
         },
         net: {
           base: {
-            usd: product.base_price__net(:usd, :unit, :single),
-            cad: product.base_price__net(:cad, :unit, :single)
+            usd: product.base_price_net(:usd, :unit, :single),
+            cad: product.base_price_net(:cad, :unit, :single)
           },
           account_cost: {
             usd: product.your_price_net(account, :usd, :unit),
@@ -36,9 +36,9 @@ module ApiHelper
             cad: product.your_price_net(account, :cad, :halfpiece)
           },
           customer: {
-            unit: product.order_price__net(current_user, :unit),
-            piece: product.order_price__net(current_user, :piece),
-            halfpiece: product.order_price__net(current_user, :halfpiece)
+            unit: product.order_price_net(current_user, :unit),
+            piece: product.order_price_net(current_user, :piece),
+            halfpiece: product.order_price_net(current_user, :halfpiece)
           }
         }
       },

--- a/app/helpers/api_helper.rb
+++ b/app/helpers/api_helper.rb
@@ -1,4 +1,88 @@
 # frozen_string_literal: true
 
 module ApiHelper
+  def self.calculate(product, account, current_user, ch_bool)
+    {
+      pricing: {
+        retail: {
+          base: {
+            usd: product.base_price__retail(:usd, :unit, :single),
+            cad: product.base_price__retail(:cad, :unit, :single)
+          },
+          markup: {
+            usd: product.retail_price(account: account, currency: :usd, unit: :unit, type: :single),
+            cad: product.retail_price(account: account, currency: :cad, unit: :unit, type: :single)
+          },
+          customer: {
+            usd: product.your_price_retail(account, :usd, :unit),
+            cad: product.your_price_retail(account, :cad, :unit)
+          }
+        },
+        net: {
+          base: {
+            usd: product.base_price__net(:usd, :unit, :single),
+            cad: product.base_price__net(:cad, :unit, :single)
+          },
+          account_cost: {
+            usd: product.your_price_net(account, :usd, :unit),
+            cad: product.your_price_net(account, :cad, :unit)
+          },
+          piece: {
+            usd: product.your_price_net(account, :usd, :piece),
+            cad: product.your_price_net(account, :cad, :piece)
+          },
+          halfpiece: {
+            usd: product.your_price_net(account, :usd, :halfpiece),
+            cad: product.your_price_net(account, :cad, :halfpiece)
+          },
+          customer: {
+            unit: product.order_price__net(current_user, :unit),
+            piece: product.order_price__net(current_user, :piece),
+            halfpiece: product.order_price__net(current_user, :halfpiece)
+          }
+        }
+      },
+      stock: product.stock(current_user)&.merge(unit: product.measured_unit)
+    }.tap do |hash|
+      hash[:uom_display_text] = product.measured_unit["uom_display_text"] if product.measured_unit["uom_display_text"].present?
+
+      if product.wallcovering?
+        hash[:measured_unit] = product.measured_unit["long"]["singular"].downcase
+        hash[:order_increment] = product.wallcovering_data.average_bolt.to_f
+      end
+
+      hash[:pricing].delete(:net) unless current_user.can_view_net_pricing?
+      hash.delete(:stock) unless current_user.has_role?(:view_stock)
+      view_objects(hash, product, ch_bool)
+    end
+  end
+
+  def self.view_objects(hash, product, ch_bool)
+    @@product = product
+    @@stock_output = hash[:stock].deep_symbolize_keys
+    @@stock_total = @@stock_output[:current][:total]
+    @@stock_unit = @@stock_output[:unit][:long][@@stock_total == 1 ? :singular : :plural]
+    @@stock_total_reserved = @@stock_output[:total_reserved]
+    @@stock_total_reserved_unit = @@stock_output[:unit][:long][@@stock_total_reserved == 1 ? :singular : :plural]
+    @@has_stock = @@stock_total.present? && @@stock_total.to_f.positive?
+    @@has_availability = @@stock_output[:availability].present?
+    @@incoming_stock = @@stock_output[:expected]
+    @@bolts = @@stock_output[:current][:bolts]
+
+    # 
+    clarencehouse_edge_case(ch_bool)
+    # 
+    @@regular_bolts_dye_lots = @@regular_bolts.group_by { |_bolt, lot| lot[:dye_lot] } if @@regular_bolts.present?
+    @@small_cuts_dye_lots = @@small_cuts.group_by { |_bolt, lot| lot[:dye_lot] } if @@small_cuts.present?
+  end
+
+  def self.clarencehouse_edge_case(ch_bool)
+    # Small cuts applies to fabric sold by the yard, excluding Clarencehouse
+    if ch_bool && @@product.fabric? && @@product.measured_unit["long"]["singular"] == "Yard"
+      @@regular_bolts, @@small_cuts = @@bolts.partition { |_bolt, lot| lot[:quantity].to_f >= 5 } if @@bolts.present?
+    else
+      @@regular_bolts = @@bolts
+      @@small_cuts = nil
+    end
+  end
 end

--- a/app/helpers/pricing_helper.rb
+++ b/app/helpers/pricing_helper.rb
@@ -75,7 +75,7 @@ module PricingHelper
 
     def uom_display_text?
       if product.measured_unit["uom_display_text"].present?
-        return "#{number_to_currency(price)} #{humanized_currency(currency)} #{product.measured_unit["uom_display_text"]}"
+        return "#{helpers.number_to_currency(price)} #{humanized_currency(currency)} #{product.measured_unit["uom_display_text"]}"
       end
     end
 
@@ -105,25 +105,25 @@ module PricingHelper
       end
 
       if unit == "sglrl" && display_for != :quick
-        content = "#{number_to_currency(price)} #{humanized_currency(currency)} per single roll (#{sold_as_units(product)})"
+        content = "#{helpers.number_to_currency(price)} #{humanized_currency(currency)} per single roll (#{sold_as_units(product)})"
       elsif unit == "sglrl" && product.product_type == "wallcovering"
-        content = helpers.content_tag(:span, "#{number_to_currency(price)} / ")
+        content = helpers.content_tag(:span, "#{helpers.number_to_currency(price)} / ")
         content << helpers.content_tag(:small, "Single Roll #{humanized_currency(currency)}")
       else
         separator = clarencehouse? ? "per" : "/"
-        content = "#{number_to_currency(price)} #{separator} #{unit} #{humanized_currency(currency)}"
+        content = "#{helpers.number_to_currency(price)} #{separator} #{unit} #{humanized_currency(currency)}"
       end
 
       if sqft_context?
-        content = helpers.content_tag(:span, "#{number_to_currency(sqft_unit_total)} #{humanized_currency(currency)} per unit", class: "per_unit_pricing")
-        content << helpers.content_tag(:span, "#{number_to_currency(price)} #{humanized_currency(currency)} per sq.ft.", class: "per_sqft_pricing")
+        content = helpers.content_tag(:span, "#{helpers.number_to_currency(sqft_unit_total)} #{humanized_currency(currency)} per unit", class: "per_unit_pricing")
+        content << helpers.content_tag(:span, "#{helpers.number_to_currency(price)} #{humanized_currency(currency)} per sq.ft.", class: "per_sqft_pricing")
       end
 
       if options["display_type"] == "available rug pad"
         if sqft_context?
-          content = "#{number_to_currency(sqft_unit_total)} #{humanized_currency(currency)}"
+          content = "#{helpers.number_to_currency(sqft_unit_total)} #{humanized_currency(currency)}"
         else
-          content = "#{number_to_currency(price)} #{humanized_currency(currency)}"
+          content = "#{helpers.number_to_currency(price)} #{humanized_currency(currency)}"
         end
       end
 

--- a/app/helpers/pricing_helper.rb
+++ b/app/helpers/pricing_helper.rb
@@ -1,97 +1,144 @@
 # frozen_string_literal: true
 
 module PricingHelper
+
   def pricing_html(pricing_type, product, account, currency, unit, display_for = nil, options = {})
-    permission = ("view_retail_pricing_" + currency.to_s).to_sym if ([pricing_type] & [:base_retail, :your_retail, :basic_pricing, :outlet_pricing]).present?
-    permission = ("view_net_pricing_" + currency.to_s).to_sym if ([pricing_type] & [:piece_base, :your_piece, :base_net, :your_net, :outlet_pricing]).present?
-
-    if current_user.can_view_pricing? && current_user.has_role?(permission)
-      price = case pricing_type
-              when :your_retail
-                # Single unit product price with your account discount * markup
-                product.your_price_retail(account, currency, unit)
-              when :base_retail
-                # Single unit product price net * 2 || Piece net price from product info * 2
-                product.base_price__retail(currency, unit, :single, account)
-              when :your_net, :your_piece
-                # Single unit product price with your account discount
-                current_account.showroom? && !current_user.has_role?(:view_your_net_price) ? nil : product.your_price_net(account, currency, unit)
-              when :base_net, :piece_base
-                # Single unit product price || Piece price from product info
-                product.base_price__net(currency, unit, :single, account)
-              when :basic_pricing, :outlet_pricing
-                # Product detail page pricing. Product price * 2 (No markup)
-                product.retail_price(account: account, currency: currency, unit: unit, type: :single)
-              end
-    end
-
-    return unless price
-
-    human_price = humanized_pricing(product, price, currency, display_for, options)
-
-    content_tag(:div, class: "product-price") do
-      if clarencehouse?
-        format_price(human_price)
-      elsif pricing_type == :outlet_pricing
-        outlet_price = product.outlet_price(account, currency, unit)
-        markup = Markup.find_for_product(account: account, product: product)
-        outlet_price = markup.apply_to(outlet_price)
-        outlet_price = format_price(outlet_price)
-        html = content_tag(:span, outlet_price, class: "#{currency}-price outlet-price line-through discontinued", data: { price: price })
-        html += content_tag(:span, human_price, class: "#{currency}-price", data: { price: price })
-        html
-      else
-        content_tag(:span, human_price, class: "#{currency}-price", data: { price: price })
-      end
-    end
+    Pricing.new(pricing_type, product, account, currency, unit, display_for = nil, options = {}, current_user).return_formatted_price
   end
 
-  def humanized_pricing(product, price, currency = :usd, display_for = nil, options = {})
-    content = ""
+  class Pricing < ApplicationController # HACK - Pulled in app controller just for that dang `clarencehouse?` bool
+    include PricingHelper
+    attr_reader :pricing_type, :product, :account, :currency, :unit, :display_for, :options, :current_user, :price
 
-    if product.measured_unit["uom_display_text"].present?
-      return "#{number_to_currency(price)} #{humanized_currency(currency)} #{product.measured_unit["uom_display_text"]}"
+    def initialize(pricing_type, product, account, currency, unit, display_for = nil, options = {}, current_user)
+      @pricing_type = pricing_type
+      @product = product
+      @account = account
+      @currency = currency
+      @unit = unit
+      @display_for = display_for
+      @options = options
+      @current_user = current_user
     end
 
-    unit = product.measured_unit["short"]["singular"].downcase
-    unit = product.measured_unit["long"]["singular"].downcase if unit == "3 panel"
+    def return_formatted_price
+      @price = send(pricing_type) if current_user.can_view_pricing? && current_user.has_role?(retail_pricing_role? || net_pricing_role?)
 
-    if unit == "dblrl"
-      price /= product.wallcovering_unit_divisor
-      unit = "sglrl"
-    end
+      return unless price
 
-    if unit == "sglrl" && display_for != :quick
-      content = "#{number_to_currency(price)} #{humanized_currency(currency)} per single roll (#{sold_as_units(product)})"
-    elsif unit == "sglrl" && product.product_type == "wallcovering"
-      content = content_tag(:span, "#{number_to_currency(price)} / ")
-      content << content_tag(:small, "Single Roll #{humanized_currency(currency)}")
-    else
-      separator = clarencehouse? ? "per" : "/"
-      content = "#{number_to_currency(price)} #{separator} #{unit} #{humanized_currency(currency)}"
-    end
-
-    if unit == "sqft" && options["total_sqft"].present?
-      unit_total = price * options["total_sqft"].to_f
-      content = content_tag(:span, "#{number_to_currency(unit_total)} #{humanized_currency(currency)} per unit", class: "per_unit_pricing")
-      content << content_tag(:span, "#{number_to_currency(price)} #{humanized_currency(currency)} per sq.ft.", class: "per_sqft_pricing")
-    end
-
-    if options["display_type"].present? && options["display_type"] == "available rug pad"
-      if unit == "sqft" && options["total_sqft"].present?
-        unit_total = price * options["total_sqft"].to_f
-        content = "#{number_to_currency(unit_total)} #{humanized_currency(currency)}"
-      else
-        content = "#{number_to_currency(price)} #{humanized_currency(currency)}"
+      helpers.content_tag(:div, class: "product-price") do
+        if clarencehouse?
+          format_price(human_price)
+        elsif pricing_type == :outlet_pricing
+          html = helpers.content_tag(:span, outlet_price, class: "#{currency}-price outlet-price line-through discontinued", data: { price: price })
+          html += helpers.content_tag(:span, human_price, class: "#{currency}-price", data: { price: price })
+          html
+        else
+          helpers.content_tag(:span, human_price, class: "#{currency}-price", data: { price: price })
+        end
       end
     end
 
-    content
-  end
+    # Ancillary methods
+    def retail_pricing_role?
+      ("view_retail_pricing_" + currency.to_s).to_sym if ([pricing_type] & [:base_retail, :your_retail, :basic_pricing, :outlet_pricing]).present?
+    end
 
-  def humanized_currency(currency)
-    symbol = currency.to_sym == :usd && current_user.can_view_cad_pricing? || current_account.currency_code == "cad" ? "USD" : ""
-    symbol = "CAD" if current_user.can_view_cad_pricing? && currency.to_sym == :cad
-    symbol
+    def net_pricing_role?
+      ("view_net_pricing_" + currency.to_s).to_sym if ([pricing_type] & [:piece_base, :your_piece, :base_net, :your_net, :outlet_pricing]).present?
+    end
+
+    def your_retail
+      product.your_price_retail(account, currency, unit)
+    end
+
+    def base_retail
+      product.base_price_retail(currency, unit, :single, account)
+    end
+
+    def your_net
+      current_account.showroom? && !current_user.has_role?(:view_your_net_price) ? nil : product.your_price_net(account, currency, unit)
+    end
+
+    def base_net
+      product.base_price_net(currency, unit, :single, account)
+    end
+
+    def basic_pricing
+      product.retail_price(account: account, currency: currency, unit: unit, type: :single)
+    end
+
+    def outlet_price
+      markup = Markup.find_for_product(account: account, product: product)
+      format_price(markup.apply_to(product.outlet_price(account, currency, unit)))
+    end
+
+    def uom_display_text?
+      if product.measured_unit["uom_display_text"].present?
+        return "#{number_to_currency(price)} #{humanized_currency(currency)} #{product.measured_unit["uom_display_text"]}"
+      end
+    end
+
+    def sqft_context?
+      unit == "sqft" && options["total_sqft"].present?
+    end
+
+    def sqft_unit_total
+      price * options["total_sqft"].to_f
+    end
+
+    def human_price
+      humanized_pricing(product, price, currency, display_for, options)
+    end
+
+    def humanized_pricing(product, price, currency = :usd, display_for = nil, options = {})
+      content = ""
+
+      uom_display_text?
+
+      unit = product.measured_unit["short"]["singular"].downcase
+      unit = product.measured_unit["long"]["singular"].downcase if unit == "3 panel"
+
+      if unit == "dblrl"
+        price /= product.wallcovering_unit_divisor
+        unit = "sglrl"
+      end
+
+      if unit == "sglrl" && display_for != :quick
+        content = "#{number_to_currency(price)} #{humanized_currency(currency)} per single roll (#{sold_as_units(product)})"
+      elsif unit == "sglrl" && product.product_type == "wallcovering"
+        content = helpers.content_tag(:span, "#{number_to_currency(price)} / ")
+        content << helpers.content_tag(:small, "Single Roll #{humanized_currency(currency)}")
+      else
+        separator = clarencehouse? ? "per" : "/"
+        content = "#{number_to_currency(price)} #{separator} #{unit} #{humanized_currency(currency)}"
+      end
+
+      if sqft_context?
+        content = helpers.content_tag(:span, "#{number_to_currency(sqft_unit_total)} #{humanized_currency(currency)} per unit", class: "per_unit_pricing")
+        content << helpers.content_tag(:span, "#{number_to_currency(price)} #{humanized_currency(currency)} per sq.ft.", class: "per_sqft_pricing")
+      end
+
+      if options["display_type"] == "available rug pad"
+        if sqft_context?
+          content = "#{number_to_currency(sqft_unit_total)} #{humanized_currency(currency)}"
+        else
+          content = "#{number_to_currency(price)} #{humanized_currency(currency)}"
+        end
+      end
+
+      content
+    end
+
+    def humanized_currency(currency)
+      symbol = currency.to_sym == :usd && current_user.can_view_cad_pricing? || current_account.currency_code == "cad" ? "USD" : ""
+      symbol = "CAD" if current_user.can_view_cad_pricing? && currency.to_sym == :cad
+      symbol
+    end
+
+    # Just to dry up the dynamic method calls on pricing_type a bit
+    alias :your_piece :your_net
+    alias :piece_base :base_net
+    alias :outlet_pricing :basic_pricing
   end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -51,7 +51,7 @@ class Product < ApplicationRecord
     account&.export? && unit != :unit ? "per_#{unit}_export" : "per_#{unit}"
   end
 
-  def base_price__net(currency = :usd, unit = :unit, type = :single, account = nil)
+  def base_price_net(currency = :usd, unit = :unit, type = :single, account = nil)
     currency = ([currency.to_s.to_sym] & [:usd, :cad]).pop
     unit = ([unit.to_s.to_sym] & [:unit, :piece, :halfpiece]).pop
     type = account&.export? ? :export : ([type.to_s.to_sym] & [:single, :tiered, :export]).pop
@@ -75,8 +75,8 @@ class Product < ApplicationRecord
     end
   end
 
-  def base_price__retail(currency = :usd, unit = :unit, type = :single, account = nil)
-    price = base_price__net(currency, unit, type, account)
+  def base_price_retail(currency = :usd, unit = :unit, type = :single, account = nil)
+    price = base_price_net(currency, unit, type, account)
     return nil if price.nil?
 
     case type
@@ -96,7 +96,7 @@ class Product < ApplicationRecord
     type = ([type.to_s.to_sym] & [:single, :tiered, :export]).pop
 
     markup = Markup.find_for_product(account: account, product: self)
-    price = base_price__net(currency, unit, type, account)
+    price = base_price_net(currency, unit, type, account)
     return nil if price.nil?
 
     case type
@@ -132,7 +132,7 @@ class Product < ApplicationRecord
     markup.apply_to(price)
   end
 
-  def order_price__net(user, unit = :unit, promo_code = nil)
+  def order_price_net(user, unit = :unit, promo_code = nil)
     pricing = order_pricing(user: user, unit: unit, promo_code: promo_code)
     pricing&.dig("order_price")
   end

--- a/test/helpers/api_helper_test.rb
+++ b/test/helpers/api_helper_test.rb
@@ -1,0 +1,35 @@
+require 'test_helper'
+
+class ApiHelperTest < ActionView::TestCase
+  def setup
+    @subject = subject
+  end
+
+  def subject
+    ApiHelper.calculate(products(:test), users.first.accounts.first, users.first, false)
+  end
+
+  test 'payload happy path' do
+    expected_payload = {:pricing=>{:retail=>{:base=>{:usd=>38.0, :cad=>64.6}, :markup=>{:usd=>19.0, :cad=>32.5}, :customer=>{:usd=>19.0, :cad=>32.5}}, :net=>{:base=>{:usd=>19.0, :cad=>32.3}, :account_cost=>{:usd=>19.0, :cad=>32.3}, :piece=>{:usd=>11.95, :cad=>nil}, :halfpiece=>{:usd=>12.45, :cad=>nil}, :customer=>{:unit=>19.0, :piece=>19.0, :halfpiece=>19.0}}}, :stock=>{"current"=>{"bolts"=>{"1971"=>{"dye_lot"=>"0", "quantity"=>27.73}, "473563"=>{"dye_lot"=>"0", "quantity"=>60.0}, "473564"=>{"dye_lot"=>"0", "quantity"=>60.0}, "473565"=>{"dye_lot"=>"0", "quantity"=>60.0}, "473566"=>{"dye_lot"=>"0", "quantity"=>60.0}, "473567"=>{"dye_lot"=>"0", "quantity"=>60.0}, "473568"=>{"dye_lot"=>"0", "quantity"=>60.0}, "473569"=>{"dye_lot"=>"0", "quantity"=>60.0}}, "memos"=>1, "total"=>447}, "expected"=>[], "availability"=>"", "total_reserved"=>0.0, :unit=>{"short"=>{"singular"=>"Yd", "plural"=>"Yds"}, "long"=>{"singular"=>"Yard", "plural"=>"Yards"}, "uom_display_text"=>nil}}}
+
+    assert_equal expected_payload, @subject
+  end
+
+  test 'view attributes happy path' do
+    expected_class_variables = [:@@product, :@@stock_output, :@@stock_total, :@@stock_unit, :@@stock_total_reserved, :@@stock_total_reserved_unit, :@@has_stock, :@@has_availability, :@@incoming_stock, :@@bolts, :@@regular_bolts, :@@small_cuts, :@@regular_bolts_dye_lots]
+
+    assert_equal expected_class_variables, ApiHelper.class_variables
+  end
+
+  test 'a sample of view attribute assignment' do
+    expected = [:"1971", {:dye_lot=>"0", :quantity=>27.73}]
+
+    assert_equal expected, @@bolts.first
+  end
+
+  test 'mass assignment of view attributes' do
+    ApiHelper.class_variables.each do |class_var|
+      refute_empty(class_var, "Class variable: #{class_var} not declared")
+    end
+  end
+end

--- a/test/helpers/pricing_helper_test.rb
+++ b/test/helpers/pricing_helper_test.rb
@@ -1,0 +1,39 @@
+require 'test_helper'
+
+class PricingHelperTest < ActionView::TestCase
+  def subject(pricing_type, iso_4217)
+    subject = PricingHelper::Pricing.new(pricing_type, products(:test), users.first.accounts.first, iso_4217, :unit, users.first).return_formatted_price
+
+    # Cheap way for cleaner specs, probably overkill all things considered.
+    Nokogiri(subject).text
+  end
+
+  test 'USD retail price' do
+    assert_equal "$19.00 / yd USD", subject(:basic_pricing, :usd)
+  end
+
+  test 'CAD retail price' do
+    assert_equal "$32.50 / yd CAD", subject(:basic_pricing, :cad)
+  end
+
+  test 'USD base net' do
+    assert_equal "$19.00 / yd USD", subject(:base_net, :usd)
+  end
+
+  test 'CAD base net' do
+    assert_equal "$32.30 / yd CAD", subject(:base_net, :cad)
+  end
+
+  test 'a pricing format that does not exist' do
+    # OFI - The code tested in this spec should return a custom error like NoPricingFormatError or something
+    assert_raise(NoMethodError) { subject(:foo, :cad) }
+  end
+
+  test 'a currency code that does not exist' do
+    # OFI - The code tested in this spec should return a custom error like NoCurrencyCodeError or something
+    assert_raise(NoMethodError) { subject(:basic_pricing, :foo) }
+
+    # TDD start point
+    # assert_raise(NoCurrencyCodeError) { subject(:basic_pricing, :foo) }
+  end
+end


### PR DESCRIPTION
# Fabricut Interview
### Conclusion
I would very much like to thank you for putting this together. I really enjoyed this format and found it very easy to get a sense of the business and the application with this interview approach. 

While looking at the list of suggested changes supplied in the readme, I felt like the api controller and the pricing helper offered the most opportunity for improvements. Given the 4 hour time box, that was what I was able to get to in this code challenge. The notes below describe my thinking along the way. Please feel free to leave a comment on any line of code and start a discussion.

Like with a lot of refactors - If I had to do this all over again, there are some things I would keep and some things I would do differently. If we were doing this for a production app, I'd love to start a conversation around the stock and pricing api feature as a whole and introduce a plan that involves a more conventional approach.
___
### Summary of notes
Assessment @ 30 min mark:
Ran into a few small snags, pretty typical for getting something new going on a machine. Nothing I couldn’t google my way out of. I added what I believe to be the easiest way to get a pg instance running to the readme.

The task at hand appears to be heavily associated with refactoring our way through the conditionals in the products controller and the pricing helper. Because the unit tests representing the business logic around the payload, pricing behavior or permissions don’t exist, I wont have any assurances along that way that I haven’t introduced a bug. Especially in the context of the business logic represented in these two files.

As it stands 30 min in, I see two schools of thought here.

1. Take the time and prove out that I can reverse engineer the business logic through unit testing, while building up the coverage required to provide confidence to the business that the refactor won’t introduce any new bugs. I will check less boxes, but the end product will be of higher quality.
2. Since it’s a time boxed interview, fail fast and go for it.

Right now 34 min in I am leaning towards option 1, but subject to change.

1 hour in:

Got a little distracted with the api controller. This is an interesting use case since it’s not your typical crud route. It’s more data aggregation while parsing business logic. Why this is a little more tricky than your typical crud route is you can see we’re building up all these instance variables.

```ruby
@product = product
@stock_output = output[:stock].deep_symbolize_keys

@stock_total = @stock_output[:current][:total]
@stock_unit = @stock_output[:unit][:long][@stock_total == 1 ? :singular : :plural]

@stock_total_reserved = @stock_output[:total_reserved]
@stock_total_reserved_unit = @stock_output[:unit][:long][@stock_total_reserved == 1 ? :singular : :plural]

@has_stock = @stock_total.present? && @stock_total.to_f.positive?
@has_availability = @stock_output[:availability].present?
@incoming_stock = @stock_output[:expected]

# Get all bolts and separate them into "regular bolts" and "small cuts"
@bolts = @stock_output[:current][:bolts]

# Small cuts applies to fabric sold by the yard, excluding Clarencehouse
if !clarencehouse? && @product.fabric? && @product.measured_unit["long"]["singular"] == "Yard"
  @regular_bolts, @small_cuts = @bolts.partition { |_bolt, lot| lot[:quantity].to_f >= 5 } if @bolts.present?
else
  @regular_bolts = @bolts
  @small_cuts = nil
end

# Group and sort by dye lot number
@regular_bolts_dye_lots = @regular_bolts.group_by { |_bolt, lot| lot[:dye_lot] } if @regular_bolts.present?
@small_cuts_dye_lots = @small_cuts.group_by { |_bolt, lot| lot[:dye_lot] } if @small_cuts.present?
```

which are obviously built up to be used as view objects in the Products partials.

Ok quick clarification - I took “refactor” to mean, make the code better without changing original behavior or introducing new features. That ruled out moving this logic into products, where it might sit more naturally.

I took a simple approach trying my best to have single responsibility methods. I’m of the school that controller actions should be simple. Dead simple. So while looking at what the existing ApiController was doing, I found that it’s functionality falls into two categories. Fetching the data, and sanitizing it to meet business logic.

What I landed on given the time/context constraints was to break up the data sanitizing up into a <namespace>_helper which just builds up the object so the view can consume it. And because the rails magic doesn’t extend to our helper, we need to make our own. Nothing here will be too ground breaking, all pretty standard stuff.

As I mentioned, views inherit all instance vars declared in the controller action that triggered it. Which is really cool for regular crud stuff. But this is slightly different. This controller ends up rendering these partials for ‘Products’, so it’s not like we can change the view because they belong to the product feature.

All that being said, we need a way for the controller to initialize all the view objects, without having all that cruft in our controller and one common way to it is a dynamic declaration. Pretty easy.

```ruby
class ApiController < ApplicationController
  include ApiHelper
  def stock_and_pricing
    ApiHelper.calculate_stock_and_pricing(Product.find(params[:sku]), current_account, current_user, clarencehouse?)
    build_view_attributes
  rescue => e
    render json: { success: false, error: e.message }, status: :unprocessable_entity
  end

  private

def build_view_attributes
    ApiHelper.class_variables.map { |cv| eval("#{cv.to_s[1..-1]} = #{cv}") }
  end
end
```

Ok, this might be slightly heretical to some, and cool to others. (PSA - Class variables are **useful**.) We can build up the view objects in a place where it makes more sense, like our data sanitizer.

```ruby
def self.view_objects(hash, product, ch_bool)
    @@product = product
    @@stock_output = hash[:stock].deep_symbolize_keys
    @@stock_total = @@stock_output[:current][:total]
		...
```

And since class variables are preserved during inheritance we can just loop through those and dynamically declare instance variables, which the view implicitly inherits.

```ruby
> @foo
  => nil
> @@foo
  => 'bar'
> eval("#{@@foo.to_s[1..-1]} = #{@@foo}")
> @foo
  => 'bar'
```

Benchmarks: The refactor just edges out the original at scale but no signifiant gain or loss is observed. That’s ok! Not all refactors are performance based. It’s nice to know that we can make the controller a bit more readable, testable, and extendable without suffering a performance hit.

```ruby
###########################################
############## Refactor ###################
###########################################
Benchmark.bm(100,000) do |x|
	x.report { <refactor> }
end 

=>
		user     system      total        real
0.003733   0.000461   0.004194 (  0.004060)

# Refactor at 10 x
Benchmark.bm(1,000,000) do |x|
	x.report { <refactor> }
end

=>
		user     system      total        real
0.004274   0.000638   0.004912 (  0.004789)

###########################################
############## Original ###################
###########################################
Benchmark.bm(100,000) do |x|
	x.report { <original code> }
end

=>
		user     system      total        real
0.004171   0.000222   0.004393 (  0.004388)

# Original at 10 x
Benchmark.bm(1,000,000) do |x|
	x.report { <original code>  }
end

=>
		user     system      total        real
0.004277   0.000569   0.004846 (  0.006677)
```

## 11-16 Take 2

Had some more time Wednesday after work so I took a crack at the pricing_helper. There is still more work to be done with this functionality but I wanted to capture the notes while everything was fresh.

At a high level, this module was very much functional. While I preserved that behavior I also introduced some state by introducing the Pricing class. This made it a lot easier to refactor since now we don’t need to pass **********everything********** as an argument, among other reasons. It also opens up some cool possibilities I’ll demonstrate here. That being said I should address the elephant in the room. Often, when we think refactor we think more condensed code. My code changes as of right now added over 40 lines of code.

I was thinking about this code from a testing perspective.

Consider the original code

```ruby
def pricing_html(pricing_type, product, account, currency, unit, display_for = nil, options = {})
    permission = ("view_retail_pricing_" + currency.to_s).to_sym if ([pricing_type] & [:base_retail, :your_retail, :basic_pricing, :outlet_pricing]).present?
    permission = ("view_net_pricing_" + currency.to_s).to_sym if ([pricing_type] & [:piece_base, :your_piece, :base_net, :your_net, :outlet_pricing]).present?

    if current_user.can_view_pricing? && current_user.has_role?(permission)
      price = case pricing_type
              when :your_retail
                # Single unit product price with your account discount * markup
                product.your_price_retail(account, currency, unit)
              when :base_retail
                # Single unit product price net * 2 || Piece net price from product info * 2
                product.base_price__retail(currency, unit, :single, account)
              when :your_net, :your_piece
                # Single unit product price with your account discount
                current_account.showroom? && !current_user.has_role?(:view_your_net_price) ? nil : product.your_price_net(account, currency, unit)
              when :base_net, :piece_base
                # Single unit product price || Piece price from product info
                product.base_price__net(currency, unit, :single, account)
              when :basic_pricing, :outlet_pricing
                # Product detail page pricing. Product price * 2 (No markup)
                product.retail_price(account: account, currency: currency, unit: unit, type: :single)
              end
    end

return unless price
```

Now the refactor

```ruby
def return_formatted_price
	@price = send(pricing_type) if current_user.can_view_pricing? && current_user.has_role?(retail_pricing_role? || net_pricing_role?)
	return unless price
```

Here rather than looping through ******all****** pricing types we can just execute the <pricing_type> method which performs the same action as the case statement. But, without the loop.

```ruby
def your_retail
  product.your_price_retail(account, currency, unit)
end

def base_retail
  product.base_price_retail(currency, unit, :single, account)
end

def your_net
  current_account.showroom? && !current_user.has_role?(:view_your_net_price) ? nil : product.your_price_net(account, currency, unit)
end

def base_net
  product.base_price_net(currency, unit, :single, account)
end

def basic_pricing
  product.retail_price(account: account, currency: currency, unit: unit, type: :single)
end
```

And with alias, we can make use of some of the dual purpose pricing_types

```ruby
# Just to dry up the dynamic method calls on pricing_type a bit
alias :your_piece :your_net
alias :piece_base :base_net
alias :outlet_pricing :basic_pricing
```

I hope you can see how with this approach the code becomes much more maintainable. We can now very easily test very specific pieces of our business logic.  There could be a whole describe block around just your_net for a random example.

```ruby
def your_net
  current_account.showroom? && !current_user.has_role?(:view_your_net_price) ? nil : product.your_price_net(account, currency, unit)
end
```

The code above is making a lot of assumptions. I know I’m picking on this code, but really it’s just representing the theme for all of the code within this module. It’s very nuanced business logic, with pieces of it that could probably be broken out entirely. Like the humanized_pricing method. As you can see, I’m still working through that method and thinking of ways to separate the concerns each of the conditionals represent.

Oh, before I forget, I should mention about the view layer that calls PricingHelper.pricing_html

```ruby
# app/views/products/show.html.erb
<%= pricing_html(:basic_pricing, @product, current_account, :usd, :unit) %>
<%= pricing_html(:basic_pricing, @product, current_account, :cad, :unit) %>
```

This view’s helpers extend to the PricingHelper module but not within the context of the Pricing class I have added. So sadly I’ve had to reference those helpers from within the Pricing class. Still looking for a better way to approach that.

```ruby
Original Code
number_to_currency(price)

Refactor
helpers.number_to_currency(price)
```

Some other things I did was move around how permissions were called. Rather than cast the value into a variable and reference it later, just reference it in real time.

```ruby
Original Code
permission = ("view_retail_pricing_" + currency.to_s).to_sym if ([pricing_type] & [:base_retail, :your_retail, :basic_pricing, :outlet_pricing]).present?
permission = ("view_net_pricing_" + currency.to_s).to_sym if ([pricing_type] & [:piece_base, :your_piece, :base_net, :your_net, :outlet_pricing]).present?

if current_user.can_view_pricing? && current_user.has_role?(permission)

Refactor
def return_formatted_price
  @price = send(pricing_type) if current_user.can_view_pricing? && current_user.has_role?(retail_pricing_role? || net_pricing_role?)
```

Here we are just calling these two predicate(ish) methods. They aren’t really true predicate methods. Notice I’m doing something kind of odd here? It looks like I’m treating these as bools with the `||` operator. `current_user.has_role?(retail_pricing_role? || net_pricing_role?)` However I’m just using the or operator as a sneaky way to execute these two setter methods back to back like the original code was doing.

```ruby
def retail_pricing_role?
  ("view_retail_pricing_" + currency.to_s).to_sym if ([pricing_type] & [:base_retail, :your_retail, :basic_pricing, :outlet_pricing]).present?
end

def net_pricing_role?
  ("view_net_pricing_" + currency.to_s).to_sym if ([pricing_type] & [:piece_base, :your_piece, :base_net, :your_net, :outlet_pricing]).present?
end
```

## 11-20 Take 3

Sorry my time has been so limited! I feel terrible this has taken me this long. Excuses aside my wife and I are in the final month of pregnancy and time is harder and harder to find.

For the final hour, I decided rather than go for another check box on the todo list, instead to add basic unit test coverage that will facilitate additional development and refactoring in the future.

Everything I did was basic stuff and there are still tons of opportunities for improvement (OPI) with this testing approach. I tried to add happy path coverage for input and outputs and a few sad path tests. It’s been a while since I’ve used minitest, so forgive me if the stubs and whatnot aren’t ideally laid out. Also, you’ll see syntax that might not be conventional for minitest. 

One thing I did like about this approach was how we were able to test PricingHelper::Pricing

```ruby
def subject(pricing_type, iso_4217)
    subject = PricingHelper::Pricing.new(pricing_type, products(:test), :accounts, iso_4217, :unit, :current_user).return_formatted_price
  end

  test 'USD retail price' do
    assert_equal "$19.00 / yd USD", subject(:basic_pricing, :usd)
  end

  test 'CAD retail price' do
    assert_equal "$32.50 / yd CAD", subject(:basic_pricing, :cad)
  end
```

This, in a way, proves out how much easier I was hoping this approach would be to test. We can now say `subject(:basic_pricing, :usd)` or `subject(:basic_pricing, :cad)` - how easy is that?

```ruby
# TDD start point
    # assert_raise(NoCurrencyCodeError) { subject(:basic_pricing, :foo) }
```

I left off with this comment in the code. This was added given my ignorance of the product. I don’t even know if it’s possible via the UI to select a country code other than USD or CAD, but I figured if it was possible - This is pretty decent place to start TDD’ing, as we do need to establish a pattern for better error handling throughout this portion of the app.

